### PR TITLE
Timeout user sessions after period of inactivity.

### DIFF
--- a/server/src/actors/api/inbound_message.rs
+++ b/server/src/actors/api/inbound_message.rs
@@ -1,5 +1,5 @@
 use actix::{AsyncContext, Handler, Message};
-use log::debug;
+use log::{debug, error};
 use uuid::Uuid;
 
 use super::super::player;
@@ -57,6 +57,9 @@ impl Handler<GlobalChat> for WebSocket {
             player.do_send(player::message::SendGlobalChat {
                 message: msg.message,
             });
+        } else {
+            error!("Got global chat message, but user is not logged in!")
+            // TODO: Handle error, when user is not logged in
         }
     }
 }

--- a/server/src/actors/api/outbound_message.rs
+++ b/server/src/actors/api/outbound_message.rs
@@ -55,3 +55,19 @@ impl Handler<GlobalChat> for WebSocket {
         ctx.text(serde_json::to_string(&msg).unwrap());
     }
 }
+
+#[derive(Message, Serialize)]
+#[serde(tag = "type")]
+#[rtype(result = "()")]
+pub struct Error {
+    pub timestamp: DateTime<Utc>,
+    pub text: String,
+}
+
+impl Handler<Error> for WebSocket {
+    type Result = ();
+
+    fn handle(&mut self, msg: Error, ctx: &mut Self::Context) -> Self::Result {
+        ctx.text(serde_json::to_string(&msg).unwrap());
+    }
+}

--- a/server/src/actors/player/message.rs
+++ b/server/src/actors/player/message.rs
@@ -1,49 +1,83 @@
 use actix::{Addr, AsyncContext, Context, Handler, Message};
 use chrono::{DateTime, Utc};
-use uuid::Uuid;
+use std::time::Instant;
 
 use super::super::api;
 use super::super::api::ApiClient;
 use super::super::server;
-use super::Player;
+use super::{Player, PlayerStatus};
 
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct Connected {
     pub api_client: Addr<ApiClient>,
-    pub session_id: Uuid,
 }
 
 impl Handler<Connected> for Player {
     type Result = ();
 
     fn handle(&mut self, msg: Connected, ctx: &mut Context<Self>) -> Self::Result {
-        if let None = self.api_client {
-            self.api_client = Some(msg.api_client.clone());
-            msg.api_client
-                .do_send(api::outbound_message::UserConnected {
-                    session_id: msg.session_id,
-                    username: self.username.clone(),
-                    player: ctx.address(),
-                });
-        } else {
-            msg.api_client
-                .do_send(api::outbound_message::ConnectionFailed {
-                    reason: "User still connected.".to_string(),
-                });
+        match self.status {
+            PlayerStatus::Connecting => {
+                self.status = PlayerStatus::Connected {
+                    api_client: msg.api_client.clone(),
+                };
+                msg.api_client
+                    .do_send(api::outbound_message::UserConnected {
+                        session_id: self.session_id.clone(),
+                        username: self.username.clone(),
+                        player: ctx.address(),
+                    });
+                self.server
+                    .do_send(server::message::GlobalChatBroadcast::system_message(
+                        format!("User '{}' connected.", self.username),
+                    ));
+            }
+            PlayerStatus::LostConnection { .. } => {
+                self.status = PlayerStatus::Connected {
+                    api_client: msg.api_client.clone(),
+                };
+                msg.api_client
+                    .do_send(api::outbound_message::UserConnected {
+                        session_id: self.session_id.clone(),
+                        username: self.username.clone(),
+                        player: ctx.address(),
+                    });
+                self.server
+                    .do_send(server::message::GlobalChatBroadcast::system_message(
+                        format!("User '{}' reconnected.", self.username),
+                    ));
+            }
+            PlayerStatus::Connected { .. } => {
+                msg.api_client
+                    .do_send(api::outbound_message::ConnectionFailed {
+                        reason: "User still connected.".to_string(),
+                    })
+            }
         }
     }
 }
 
 #[derive(Message)]
 #[rtype(result = "()")]
-pub struct Disconnected {}
+pub struct Disconnected {
+    pub reason: String,
+}
 
 impl Handler<Disconnected> for Player {
     type Result = ();
 
-    fn handle(&mut self, _msg: Disconnected, _ctx: &mut Context<Self>) -> Self::Result {
-        self.api_client = None;
+    fn handle(&mut self, msg: Disconnected, _ctx: &mut Context<Self>) -> Self::Result {
+        self.status = PlayerStatus::LostConnection {
+            last_seen: Instant::now(),
+        };
+        self.server
+            .do_send(server::message::GlobalChatBroadcast::system_message(
+                format!(
+                    "User '{}' disconnected. Reason: {}",
+                    self.username, msg.reason
+                ),
+            ));
         // TODO: wait, then skip in game, later drop from game
     }
 }
@@ -58,12 +92,11 @@ impl Handler<SendGlobalChat> for Player {
     type Result = ();
 
     fn handle(&mut self, msg: SendGlobalChat, _ctx: &mut Context<Self>) -> Self::Result {
-        self.server.do_send(server::message::GlobalChatBroadcast {
-            timestamp: Utc::now(),
-            system_msg: false,
-            username: self.username.clone(),
-            message: msg.message,
-        })
+        self.server
+            .do_send(server::message::GlobalChatBroadcast::user_message(
+                self.username.clone(),
+                msg.message,
+            ))
     }
 }
 
@@ -80,13 +113,14 @@ impl Handler<ReceiveGlobalChat> for Player {
     type Result = ();
 
     fn handle(&mut self, msg: ReceiveGlobalChat, _ctx: &mut Context<Self>) -> Self::Result {
-        if let Some(api_client) = &self.api_client {
+        if let PlayerStatus::Connected { api_client } = &self.status {
             api_client.do_send(api::outbound_message::GlobalChat {
-                timestamp: Utc::now(),
+                timestamp: msg.timestamp,
                 system_msg: msg.system_msg,
-                username: self.username.clone(),
+                username: msg.username,
                 message: msg.message,
             })
         }
+        //TODO: else add message to buffer?
     }
 }

--- a/server/src/actors/player/mod.rs
+++ b/server/src/actors/player/mod.rs
@@ -3,3 +3,4 @@ mod player;
 pub mod message;
 
 pub use player::Player;
+pub use player::PlayerStatus;

--- a/server/src/actors/player/player.rs
+++ b/server/src/actors/player/player.rs
@@ -1,33 +1,57 @@
-use actix::{Actor, Addr, Context};
+use actix::{Actor, ActorContext, Addr, AsyncContext, Context};
 use log::info;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
 
 use super::super::api::ApiClient;
+use super::super::server;
 use super::super::server::Server;
+
+const PLAYER_TIMEOUT_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+const PLAYER_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+pub enum PlayerStatus {
+    Connecting,
+    Connected { api_client: Addr<ApiClient> },
+    LostConnection { last_seen: Instant },
+}
 
 pub struct Player {
     pub server: Addr<Server>,
-    pub api_client: Option<Addr<ApiClient>>,
+    pub session_id: Uuid,
     pub username: String,
+    pub status: PlayerStatus,
 }
 
 impl Actor for Player {
     type Context = Context<Self>;
 
-    fn started(&mut self, _ctx: &mut Context<Self>) {
-        info!("Player {} joined.", self.username);
-    }
-
-    fn stopped(&mut self, _ctx: &mut Context<Self>) {
-        info!("Player {} left.", self.username);
+    fn started(&mut self, ctx: &mut Context<Self>) {
+        self.timeout(ctx);
     }
 }
 
 impl Player {
-    pub fn new(server: Addr<Server>, username: String) -> Self {
+    pub fn new(server: Addr<Server>, session_id: Uuid, username: String) -> Self {
         Player {
             server,
-            api_client: None,
+            session_id,
             username,
+            status: PlayerStatus::Connecting,
         }
+    }
+
+    fn timeout(&self, ctx: &mut <Self as Actor>::Context) {
+        ctx.run_interval(PLAYER_TIMEOUT_CHECK_INTERVAL, |act, ctx| {
+            if let PlayerStatus::LostConnection { last_seen } = act.status {
+                if Instant::now().duration_since(last_seen) > PLAYER_TIMEOUT {
+                    info!("Player {} timed out.", act.username);
+                    act.server.do_send(server::message::DestroySession {
+                        session_id: act.session_id,
+                    });
+                    ctx.stop();
+                }
+            }
+        });
     }
 }

--- a/server/src/actors/server/message.rs
+++ b/server/src/actors/server/message.rs
@@ -1,5 +1,5 @@
 use actix::{Actor, Addr, AsyncContext, Context, Handler, Message};
-use log::debug;
+use log::{debug, warn};
 use uuid::Uuid;
 
 use super::super::api::{outbound_message, ApiClient};
@@ -7,7 +7,7 @@ use super::super::player;
 use super::super::player::Player;
 use super::{PlayerInfo, Server};
 use chrono::{DateTime, Utc};
-use std::collections::hash_map::{Entry, OccupiedEntry};
+use std::collections::hash_map::Entry;
 
 #[derive(Message)]
 #[rtype(result = "()")]

--- a/server/src/actors/server/mod.rs
+++ b/server/src/actors/server/mod.rs
@@ -2,4 +2,5 @@ mod server;
 
 pub mod message;
 
+use server::PlayerInfo;
 pub use server::Server;

--- a/server/src/actors/server/server.rs
+++ b/server/src/actors/server/server.rs
@@ -8,9 +8,14 @@ use super::super::player::Player;
 //     addr: Addr<Game>,
 // }
 
+pub(super) struct PlayerInfo {
+    pub addr: Addr<Player>,
+    pub username: String,
+}
+
 #[derive(Default)]
 pub struct Server {
-    pub players: HashMap<Uuid, Addr<Player>>,
+    pub(super) players: HashMap<Uuid, PlayerInfo>,
     // pub games: HashMap<String, GameInfo>,
 }
 


### PR DESCRIPTION
Main idea:
- Send heartbeat every 5 seconds
- Drop connection after 30 seconds without response
- Keep user session active for 5 minutes (after timeout or user leaving/refresh/...)
  - User can reconnect using his `session_id` during the next 5 minutes
  - After 5 minutes destroy the session


Closes #3 